### PR TITLE
Update root envs to use latest deps

### DIFF
--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version >=12
+  - cuda-version =11.8
 
   - alchemiscale-client =0.6.2
 

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -10,15 +10,14 @@ dependencies:
   - alchemiscale-client =0.6.2
 
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.1.4
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange
+  - gufe =1.6.0
+  - openfe =1.6.0
+  - openmm =8.2.0
+  - openmmforcefields =0.17.0
+  - openff-interchange =0.4.5
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -28,5 +27,5 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.1
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.2
+    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -16,7 +16,8 @@ dependencies:
   - gufe =1.6.0
   - openfe =1.6.0
   - openmm =8.2.0
-  - openmmforcefields =0.17.0
+  - openmmforcefields =0.15.0
+  - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version =11.8
+  - cuda-version >=12
 
   - alchemiscale-client =0.6.2
 

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -19,6 +19,7 @@ dependencies:
   - openmmforcefields =0.15.0
   - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
+  - pontibus =0.1.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -29,4 +30,3 @@ dependencies:
 
   - pip:
     - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.2
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -19,9 +19,7 @@ dependencies:
   - openmmforcefields =0.15.0
   - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
+  - pontibus =0.1.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
-
-  - pip:
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -10,18 +10,17 @@ dependencies:
   - alchemiscale-compute =0.6.2
   
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.1.4
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange
+  - gufe =1.6.0
+  - openfe =1.6.0
+  - openmm =8.2.0
+  - openmmforcefields =0.17.0
+  - openff-interchange =0.4.5
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2
+    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -16,7 +16,8 @@ dependencies:
   - gufe =1.6.0
   - openfe =1.6.0
   - openmm =8.2.0
-  - openmmforcefields =0.17.0
+  - openmmforcefields =0.15.0
+  - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version =11.8
+  - cuda-version >=12
 
   - alchemiscale-compute =0.6.2
   

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version >=12
+  - cuda-version =11.8
 
   - alchemiscale-compute =0.6.2
   

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -10,15 +10,14 @@ dependencies:
   - alchemiscale-compute =0.6.2
   
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.1.4
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange
+  - gufe =1.6.0
+  - openfe =1.6.0
+  - openmm =8.2.0
+  - openmmforcefields =0.17.0
+  - openff-interchange =0.4.5
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -29,4 +28,5 @@ dependencies:
   - zstandard
 
   - pip:
-    - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.2.1
+    - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.2.2
+    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -16,7 +16,8 @@ dependencies:
   - gufe =1.6.0
   - openfe =1.6.0
   - openmm =8.2.0
-  - openmmforcefields =0.17.0
+  - openmmforcefields =0.15.0
+  - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -19,6 +19,7 @@ dependencies:
   - openmmforcefields =0.15.0
   - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
+  - pontibus =0.1.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -30,4 +31,3 @@ dependencies:
 
   - pip:
     - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.2.2
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version =11.8
+  - cuda-version >=12
 
   - alchemiscale-compute =0.6.2
   

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version >=12
+  - cuda-version =11.8
 
   - alchemiscale-compute =0.6.2
   

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version =11.8
+  - cuda-version >=12
 
   - alchemiscale-server =0.6.2
 

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -16,7 +16,8 @@ dependencies:
   - gufe =1.6.0
   - openfe =1.6.0
   - openmm =8.2.0
-  - openmmforcefields =0.17.0
+  - openmmforcefields =0.15.0
+  - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -10,15 +10,14 @@ dependencies:
   - alchemiscale-server =0.6.2
 
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.1.4
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange
+  - gufe =1.6.0
+  - openfe =1.6.0
+  - openmm =8.2.0
+  - openmmforcefields =0.17.0
+  - openff-interchange =0.4.5
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -31,5 +30,5 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.1
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.2
+    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version >=12
+  - cuda-version =11.8
 
   - alchemiscale-server =0.6.2
 

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -19,6 +19,7 @@ dependencies:
   - openmmforcefields =0.15.0
   - openff-toolkit =0.17.0
   - openff-interchange =0.4.5
+  - pontibus =0.1.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -32,4 +33,3 @@ dependencies:
 
   - pip:
     - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.2
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.1.0


### PR DESCRIPTION
Includes:
- gufe v1.6.0
- openfe v1.6.0
- openmm v8.2.0
- openmmforcefields v0.15.0
- openff-toolkit v0.17.0
- openff-interchange v0.4.5
