### PR TITLE
Stack update for `root` instance scheduled for 2026.01

### DIFF
--- a/.github/workflows/build-root-docker.yml
+++ b/.github/workflows/build-root-docker.yml
@@ -27,12 +27,15 @@ jobs:
         image: 
           - 'alchemiscale.org-root-server' 
           - 'alchemiscale.org-root-compute'
+          - 'alchemiscale.org-root-compute-experimental'
           - 'alchemiscale.org-root-fah-compute'
         include:
           - image: 'alchemiscale.org-root-server'
             dockerfile: 'deployments/root/docker/alchemiscale-server/Dockerfile'
           - image: 'alchemiscale.org-root-compute'
             dockerfile: 'deployments/root/docker/alchemiscale-compute/Dockerfile'
+          - image: 'alchemiscale.org-root-compute-experimental'
+            dockerfile: 'deployments/root/docker/alchemiscale-compute-experimental/Dockerfile'
           - image: 'alchemiscale.org-root-fah-compute'
             dockerfile: 'deployments/root/docker/alchemiscale-fah-compute/Dockerfile'
     permissions:

--- a/.github/workflows/build-root-docker.yml
+++ b/.github/workflows/build-root-docker.yml
@@ -27,15 +27,15 @@ jobs:
         image: 
           - 'alchemiscale.org-root-server' 
           - 'alchemiscale.org-root-compute'
-          - 'alchemiscale.org-root-compute-experimental'
+          #- 'alchemiscale.org-root-compute-experimental'
           - 'alchemiscale.org-root-fah-compute'
         include:
           - image: 'alchemiscale.org-root-server'
             dockerfile: 'deployments/root/docker/alchemiscale-server/Dockerfile'
           - image: 'alchemiscale.org-root-compute'
             dockerfile: 'deployments/root/docker/alchemiscale-compute/Dockerfile'
-          - image: 'alchemiscale.org-root-compute-experimental'
-            dockerfile: 'deployments/root/docker/alchemiscale-compute-experimental/Dockerfile'
+          #- image: 'alchemiscale.org-root-compute-experimental'
+          #  dockerfile: 'deployments/root/docker/alchemiscale-compute-experimental/Dockerfile'
           - image: 'alchemiscale.org-root-fah-compute'
             dockerfile: 'deployments/root/docker/alchemiscale-fah-compute/Dockerfile'
     permissions:

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -7,18 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-client =0.7.1
+  - alchemiscale-client =0.7.2
 
   # openmm protocols
-  - feflow =0.1.4
+  - feflow =0.2.0
 
   # additional pins
   - gufe =1.7.1
   - openfe =1.8.0
   - openmm =8.2.0
-  - openmmforcefields =0.15.0
+  - openmmforcefields =0.15.1
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.9
+  - openff-interchange =0.4.11
   - pontibus =0.4.0
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -13,13 +13,13 @@ dependencies:
   - feflow =0.1.4
 
   # additional pins
-  - gufe =1.6.1
-  - openfe =1.6.1
+  - gufe =1.7.1
+  - openfe =1.8.0
   - openmm =8.2.0
   - openmmforcefields =0.15.0
-  - openff-toolkit =0.17.1
-  - openff-interchange =0.4.8
-  - pontibus =0.2.0
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.9
+  - pontibus =0.4.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -29,4 +29,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.1

--- a/deployments/root/conda-envs/alchemiscale-client.yml
+++ b/deployments/root/conda-envs/alchemiscale-client.yml
@@ -29,4 +29,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -30,4 +30,4 @@ dependencies:
   - python-kubernetes
 
   - pip:
-    - git+https://github.com/datryllic/alchemiscale-k8s.git@main
+    - git+https://github.com/datryllic/alchemiscale-k8s.git#subdirectory=pkg@main

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -25,9 +25,9 @@ dependencies:
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
-  #
+
   # alchemiscale-k8s dependencies
   - python-kubernetes
 
   - pip:
-    - git+https://github.com/datryllic/alchemiscale-k8s.git#subdirectory=pkg@main
+    - "git+https://github.com/datryllic/alchemiscale-k8s.git@main#subdirectory=pkg"

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -15,7 +15,6 @@ dependencies:
   # additional pins
   - gufe =1.7.1
   - openfe =1.8.0
-  - openmm =8.2.0
   - openmm =8.4.0
   - openmmforcefields =0.15.1
   - openff-toolkit =0.18.0

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -1,0 +1,33 @@
+name: alchemiscale-compute-experimental
+channels:
+  - conda-forge
+
+dependencies:
+  - pip
+  - python =3.12
+  - cuda-version =11.8
+
+  - alchemiscale-compute =0.7.2
+  
+  # openmm protocols
+  - feflow =0.2.0
+
+  # additional pins
+  - gufe =1.7.1
+  - openfe =1.8.0
+  - openmm =8.2.0
+  - openmm =8.4.0
+  - openmmforcefields =0.15.1
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.11
+  - pontibus =0.4.0
+  - espaloma =0.4.0
+
+  ## pins due to breaking changes
+  - libsqlite<3.49  # newer versions cause diskcache to fail
+  #
+  # alchemiscale-k8s dependencies
+  - python-kubernetes
+
+  - pip:
+    - git+https://github.com/datryllic/alchemiscale-k8s.git@main

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pip
   - python =3.12
-  - cuda-version =11.8
+  - cuda-version =12
 
   - alchemiscale-compute =0.7.2
   

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -28,4 +28,4 @@ dependencies:
   - python-kubernetes
 
   - pip:
-    - git+https://github.com/datryllic/alchemiscale-k8s.git@main
+    - git+https://github.com/datryllic/alchemiscale-k8s.git#subdirectory=pkg@main

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -28,4 +28,4 @@ dependencies:
   - python-kubernetes
 
   - pip:
-    - git+https://github.com/datryllic/alchemiscale-k8s.git#subdirectory=pkg@main
+    - "git+https://github.com/datryllic/alchemiscale-k8s.git@main#subdirectory=pkg"

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -7,19 +7,25 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-compute =0.7.1
+  - alchemiscale-compute =0.7.2
   
   # openmm protocols
-  - feflow =0.1.4
+  - feflow =0.2.0
 
   # additional pins
   - gufe =1.7.1
   - openfe =1.8.0
   - openmm =8.2.0
-  - openmmforcefields =0.15.0
+  - openmmforcefields =0.15.1
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.9
+  - openff-interchange =0.4.11
   - pontibus =0.4.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
+
+  # alchemiscale-k8s dependencies
+  - python-kubernetes
+
+  - pip:
+    - git+https://github.com/datryllic/alchemiscale-k8s.git@main

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -13,13 +13,13 @@ dependencies:
   - feflow =0.1.4
 
   # additional pins
-  - gufe =1.6.1
-  - openfe =1.6.1
+  - gufe =1.7.1
+  - openfe =1.8.0
   - openmm =8.2.0
   - openmmforcefields =0.15.0
-  - openff-toolkit =0.17.1
-  - openff-interchange =0.4.8
-  - pontibus =0.2.0
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.9
+  - pontibus =0.4.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -7,19 +7,19 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-compute =0.7.1
+  - alchemiscale-compute =0.7.2
   
   # openmm protocols
   - feflow =0.1.4
 
   # additional pins
-  - gufe =1.6.1
-  - openfe =1.6.1
+  - gufe =1.7.1
+  - openfe =1.8.0
   - openmm =8.2.0
   - openmmforcefields =0.15.0
-  - openff-toolkit =0.17.1
-  - openff-interchange =0.4.8
-  - pontibus =0.2.0
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.9
+  - pontibus =0.4.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -10,15 +10,15 @@ dependencies:
   - alchemiscale-compute =0.7.2
   
   # openmm protocols
-  - feflow =0.1.4
+  - feflow =0.2.0
 
   # additional pins
   - gufe =1.7.1
   - openfe =1.8.0
   - openmm =8.2.0
-  - openmmforcefields =0.15.0
+  - openmmforcefields =0.15.1
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.9
+  - openff-interchange =0.4.11
   - pontibus =0.4.0
 
   ## pins due to breaking changes
@@ -30,4 +30,4 @@ dependencies:
   - zstandard
 
   - pip:
-    - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.2.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.3

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -30,4 +30,4 @@ dependencies:
   - zstandard
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.1

--- a/deployments/root/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-fah-compute.yml
@@ -30,4 +30,4 @@ dependencies:
   - zstandard
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -13,13 +13,13 @@ dependencies:
   - feflow =0.1.4
 
   # additional pins
-  - gufe =1.6.1
-  - openfe =1.6.1
+  - gufe =1.7.1
+  - openfe =1.8.0
   - openmm =8.2.0
   - openmmforcefields =0.15.0
-  - openff-toolkit =0.17.1
-  - openff-interchange =0.4.8
-  - pontibus =0.2.0
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.9
+  - pontibus =0.4.0
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -7,18 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-server =0.7.1
+  - alchemiscale-server =0.7.2
 
   # openmm protocols
-  - feflow =0.1.4
+  - feflow =0.2.0
 
   # additional pins
   - gufe =1.7.1
   - openfe =1.8.0
   - openmm =8.2.0
-  - openmmforcefields =0.15.0
+  - openmmforcefields =0.15.1
   - openff-toolkit =0.18.0
-  - openff-interchange =0.4.9
+  - openff-interchange =0.4.11
   - pontibus =0.4.0
 
   ## pins due to breaking changes

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -32,4 +32,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.1

--- a/deployments/root/conda-envs/alchemiscale-server.yml
+++ b/deployments/root/conda-envs/alchemiscale-server.yml
@@ -32,4 +32,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.3
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.0

--- a/deployments/root/docker/alchemiscale-compute-experimental/Dockerfile
+++ b/deployments/root/docker/alchemiscale-compute-experimental/Dockerfile
@@ -1,0 +1,21 @@
+FROM mambaorg/micromamba:1.5.10
+
+LABEL org.opencontainers.image.source=https://github.com/OpenFreeEnergy/alchemiscale.org-deployment
+LABEL org.opencontainers.image.description="deployable experimental compute services for alchemiscale.org-root"
+LABEL org.opencontainers.image.licenses=MIT
+
+# Don't buffer stdout & stderr streams, so if there is a crash no partial buffer output is lost
+# https://docs.python.org/3/using/cmdline.html#cmdoption-u
+ENV PYTHONUNBUFFERED=1
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER deployments/root/conda-envs/alchemiscale-compute-experimental.yml /tmp/env.yaml
+RUN micromamba install -y -n base git -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+# Ensure that conda environment is automatically activated
+# https://github.com/mamba-org/micromamba-docker#running-commands-in-dockerfile-within-the-conda-environment
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+WORKDIR /home/mambauser
+
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "/opt/conda/bin/alchemiscale"]


### PR DESCRIPTION
Includes the following updates to the stack:
- gufe =1.7.1
- openfe =1.8.0
- openff-toolkit =0.18.0
- openff-interchange =0.4.11
- pontibus =0.4.0
- feflow =0.2.0
