### PR TITLE
ASAP : pin openff interchange

### DIFF
--- a/deployments/asap/conda-envs/alchemiscale-client.yml
+++ b/deployments/asap/conda-envs/alchemiscale-client.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange =0.4.2
+  - openff-interchange =0.4.1
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-client.yml
+++ b/deployments/asap/conda-envs/alchemiscale-client.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange
+  - openff-interchange =0.4.2
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-compute.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange =0.4.2
+  - openff-interchange =0.4.1
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-compute.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange
+  - openff-interchange =0.4.2
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange =0.4.2
+  - openff-interchange =0.4.1
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange
+  - openff-interchange =0.4.2
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-server.yml
+++ b/deployments/asap/conda-envs/alchemiscale-server.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange =0.4.2
+  - openff-interchange =0.4.1
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail

--- a/deployments/asap/conda-envs/alchemiscale-server.yml
+++ b/deployments/asap/conda-envs/alchemiscale-server.yml
@@ -18,7 +18,7 @@ dependencies:
   - openmm =8.1.2
   - openmmforcefields >=0.14.2
   - openff-units =0.2.2
-  - openff-interchange
+  - openff-interchange =0.4.2
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail


### PR DESCRIPTION
Pinning `openff-interchange` for ASAP envs; preserves compatibility with `openfe` 1.4.0.