### PR TITLE
update link

### DIFF
--- a/deployments/root/README.md
+++ b/deployments/root/README.md
@@ -20,4 +20,4 @@ Once installed, activate the environment::
 
 You may wish to install other packages into this environment, such as `jupyterlab`.
 
-See the [`alchemiscale` User Guide](https://docs.alchemiscale.org/en/latest/user_guide.html) for further details on how to connect and interact with the deployment.
+See the [`alchemiscale` User Guide](https://docs.alchemiscale.org/en/stable/user_guide/index.html) for further details on how to connect and interact with the deployment.


### PR DESCRIPTION
Updated "User Guide" link in the `alchemiscale.org - root deployment` `README.md`.

The existing link results in 404. [[Link]](https://docs.alchemiscale.org/en/latest/user_guide.html)