### PR TITLE
Updated `asap` instance environments for parity with `root` environment

### DIFF
--- a/deployments/asap/conda-envs/alchemiscale-client.yml
+++ b/deployments/asap/conda-envs/alchemiscale-client.yml
@@ -7,18 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-client =0.6.2
+  - alchemiscale-client =0.7.2
 
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.2.0
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange =0.4.1
+  - gufe =1.7.1
+  - openfe =1.8.0
+  - openmm =8.2.0
+  - openmmforcefields =0.15.1
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.11
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -28,5 +28,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.1
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.1

--- a/deployments/asap/conda-envs/alchemiscale-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-compute.yml
@@ -7,21 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-compute =0.6.2
+  - alchemiscale-compute =0.7.2
   
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.2.0
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange =0.4.1
+  - gufe =1.7.1
+  - openfe =1.8.0
+  - openmm =8.2.0
+  - openmmforcefields =0.15.1
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.11
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
-
-  - pip:
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2

--- a/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-fah-compute.yml
@@ -7,18 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-compute =0.6.2
+  - alchemiscale-compute =0.7.2
   
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.2.0
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange =0.4.1
+  - gufe =1.7.1
+  - openfe =1.8.0
+  - openmm =8.2.0
+  - openmmforcefields =0.15.1
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.11
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -29,4 +29,4 @@ dependencies:
   - zstandard
 
   - pip:
-    - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.2.1
+    - git+https://github.com/openforcefield/alchemiscale-fah.git@v0.3.1

--- a/deployments/asap/conda-envs/alchemiscale-server.yml
+++ b/deployments/asap/conda-envs/alchemiscale-server.yml
@@ -7,18 +7,18 @@ dependencies:
   - python =3.12
   - cuda-version =11.8
 
-  - alchemiscale-server =0.6.2
+  - alchemiscale-server =0.7.2
 
   # openmm protocols
-  - feflow =0.1.3
+  - feflow =0.2.0
 
   # additional pins
-  - gufe =1.3.0
-  - openfe =1.4.0
-  - openmm =8.1.2
-  - openmmforcefields >=0.14.2
-  - openff-units =0.2.2
-  - openff-interchange =0.4.1
+  - gufe =1.7.1
+  - openfe =1.8.0
+  - openmm =8.2.0
+  - openmmforcefields =0.15.1
+  - openff-toolkit =0.18.0
+  - openff-interchange =0.4.11
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
@@ -31,5 +31,4 @@ dependencies:
   - plyvel
 
   - pip:
-    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.2.1
-    - git+https://github.com/OpenFreeEnergy/pontibus.git@v0.0.2
+    - git+https://github.com/OpenFreeEnergy/alchemiscale-fah.git@v0.3.1


### PR DESCRIPTION
We are upgrading the `asap` instance to have version parity with latest `root` instance. This will allow ASAP Discovery to use more recent features of the OpenFE stack.
