### PR TITLE
Added alchemiscale-hpc v0.1.0 to all compute envs

### DIFF
--- a/deployments/asap/conda-envs/alchemiscale-compute.yml
+++ b/deployments/asap/conda-envs/alchemiscale-compute.yml
@@ -22,3 +22,5 @@ dependencies:
 
   ## pins due to breaking changes
   - libsqlite<3.49  # newer versions cause diskcache to fail
+  - pip:
+    - "git+https://github.com/datryllic/alchemiscale-hpc.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute-experimental.yml
@@ -30,3 +30,4 @@ dependencies:
 
   - pip:
     - "git+https://github.com/datryllic/alchemiscale-k8s.git@v0.1.0#subdirectory=pkg"
+    - "git+https://github.com/datryllic/alchemiscale-hpc.git@v0.1.0

--- a/deployments/root/conda-envs/alchemiscale-compute.yml
+++ b/deployments/root/conda-envs/alchemiscale-compute.yml
@@ -29,3 +29,4 @@ dependencies:
 
   - pip:
     - "git+https://github.com/datryllic/alchemiscale-k8s.git@v0.1.0#subdirectory=pkg"
+    - "git+https://github.com/datryllic/alchemiscale-hpc.git@v0.1.0


### PR DESCRIPTION
Testing alchemiscale-hpc in both `root` and `asap` deployments.
This gives these deployments access to the SLURM autoscaler.
